### PR TITLE
chore: add open vsx publishing support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 *.vsix
 .vscode
+.envrc

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Luke OMalley
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 
 <div align="center" style="display: flex; align-items: center; justify-content: center; margin-bottom: 1rem;">
 <img style="margin-right: 1rem;" alt="Visual Studio Marketplace Installs" src="https://img.shields.io/visual-studio-marketplace/i/lukeomalley.dark-rock-theme"/>
-
-<img alt="Visual Studio Marketplace Rating (Stars)" src="https://img.shields.io/visual-studio-marketplace/stars/lukeomalley.dark-rock-theme">
+<img style="margin-right: 1rem;" alt="Visual Studio Marketplace Rating (Stars)" src="https://img.shields.io/visual-studio-marketplace/stars/lukeomalley.dark-rock-theme">
+<img style="margin-right: 1rem;" alt="Open VSX Downloads" src="https://img.shields.io/open-vsx/dt/lukeomalley/dark-rock-theme"/>
+<img alt="Open VSX Rating" src="https://img.shields.io/open-vsx/stars/lukeomalley/dark-rock-theme"/>
 </div>
 
 <p></p>

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "version": "1.1.0",
   "publisher": "lukeomalley",
   "author": "Luke OMalley",
+  "license": "MIT",
   "homepage": "https://github.com/lukeomalley/dark-rock-theme",
   "bugs": {
     "url": "https://github.com/lukeomalley/dark-rock-theme",
@@ -25,6 +26,12 @@
   "categories": [
     "Themes"
   ],
+  "scripts": {
+    "package": "vsce package",
+    "publish:vscode": "vsce publish",
+    "publish:ovsx": "ovsx publish -p $OPEN_VSX_ACCESS_TOKEN",
+    "publish:all": "npm run publish:vscode && npm run publish:ovsx"
+  },
   "contributes": {
     "themes": [
       {


### PR DESCRIPTION
- Add MIT LICENSE file
- Add license field and publish scripts to package.json
- Add Open VSX badges to README
- Add .envrc to .gitignore

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add MIT license, Open VSX badges, and publish scripts; ignore .envrc.
> 
> - **Project metadata and distribution**:
>   - Add `LICENSE` (MIT) and set `"license": "MIT"` in `package.json`.
>   - Add publish scripts in `package.json` for VS Code and Open VSX (`vsce`, `ovsx`, and `publish:all`).
> - **Docs**:
>   - Update `README.md` badges to include Open VSX download and rating.
> - **Repo hygiene**:
>   - Add `.envrc` to `.gitignore`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be96875acf4307c014b070b402d63c406d75b4c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->