### PR TITLE
feat: add Solidity-specific syntax highlighting rules

### DIFF
--- a/themes/dark-rock-color-theme.json
+++ b/themes/dark-rock-color-theme.json
@@ -2223,19 +2223,19 @@
       }
     },
     {
-      "scope": "storage.type.contract, storage.type.interface, storage.type.library, storage.type.struct, storage.type.enum",
+      "scope": "source.solidity storage.type.contract, source.solidity storage.type.interface, source.solidity storage.type.library, source.solidity storage.type.struct, source.solidity storage.type.enum",
       "settings": {
         "foreground": "#EA6962"
       }
     },
     {
-      "scope": "entity.name.type.contract, entity.name.type.interface, entity.name.type.library, entity.name.type.struct, entity.name.type.enum, entity.name.type.event, entity.name.type.error",
+      "scope": "source.solidity entity.name.type.contract, source.solidity entity.name.type.interface, source.solidity entity.name.type.library, source.solidity entity.name.type.struct, source.solidity entity.name.type.enum, source.solidity entity.name.type.event, source.solidity entity.name.type.error",
       "settings": {
         "foreground": "#7DAEA3"
       }
     },
     {
-      "scope": "storage.type.modifier.extendedscope",
+      "scope": "source.solidity storage.type.modifier.extendedscope",
       "settings": {
         "foreground": "#D3869B"
       }
@@ -2247,7 +2247,7 @@
       }
     },
     {
-      "scope": "storage.type.modifier.access, storage.type.modifier.payable, storage.type.modifier.readonly",
+      "scope": "source.solidity storage.type.modifier.access, source.solidity storage.type.modifier.payable, source.solidity storage.type.modifier.readonly",
       "settings": {
         "foreground": "#E78A4E"
       }

--- a/themes/dark-rock-color-theme.json
+++ b/themes/dark-rock-color-theme.json
@@ -2241,7 +2241,7 @@
       }
     },
     {
-      "scope": "storage.type.function, entity.name.function",
+      "scope": "source.solidity storage.type.function, source.solidity entity.name.function",
       "settings": {
         "foreground": "#A9B665"
       }
@@ -2253,13 +2253,13 @@
       }
     },
     {
-      "scope": "support.type.primitive",
+      "scope": "source.solidity support.type.primitive",
       "settings": {
         "foreground": "#D8A657"
       }
     },
     {
-      "scope": "keyword.control.import, keyword.control.pragma, keyword.control.using, keyword.control.flow",
+      "scope": "source.solidity keyword.control.import, source.solidity keyword.control.pragma, source.solidity keyword.control.using, source.solidity keyword.control.flow",
       "settings": {
         "foreground": "#89B482"
       }

--- a/themes/dark-rock-color-theme.json
+++ b/themes/dark-rock-color-theme.json
@@ -2223,6 +2223,48 @@
       }
     },
     {
+      "scope": "storage.type.contract, storage.type.interface, storage.type.library, storage.type.struct, storage.type.enum",
+      "settings": {
+        "foreground": "#EA6962"
+      }
+    },
+    {
+      "scope": "entity.name.type.contract, entity.name.type.interface, entity.name.type.library, entity.name.type.struct, entity.name.type.enum, entity.name.type.event, entity.name.type.error",
+      "settings": {
+        "foreground": "#7DAEA3"
+      }
+    },
+    {
+      "scope": "storage.type.modifier.extendedscope",
+      "settings": {
+        "foreground": "#D3869B"
+      }
+    },
+    {
+      "scope": "storage.type.function, entity.name.function",
+      "settings": {
+        "foreground": "#A9B665"
+      }
+    },
+    {
+      "scope": "storage.type.modifier.access, storage.type.modifier.payable, storage.type.modifier.readonly",
+      "settings": {
+        "foreground": "#E78A4E"
+      }
+    },
+    {
+      "scope": "support.type.primitive",
+      "settings": {
+        "foreground": "#D8A657"
+      }
+    },
+    {
+      "scope": "keyword.control.import, keyword.control.pragma, keyword.control.using, keyword.control.flow",
+      "settings": {
+        "foreground": "#89B482"
+      }
+    },
+    {
       "scope": "token.info-token",
       "settings": {
         "foreground": "#6796E6"

--- a/themes/light-rock-color-theme.json
+++ b/themes/light-rock-color-theme.json
@@ -2050,19 +2050,19 @@
       }
     },
     {
-      "scope": "storage.type.contract, storage.type.interface, storage.type.library, storage.type.struct, storage.type.enum",
+      "scope": "source.solidity storage.type.contract, source.solidity storage.type.interface, source.solidity storage.type.library, source.solidity storage.type.struct, source.solidity storage.type.enum",
       "settings": {
         "foreground": "#9D0006"
       }
     },
     {
-      "scope": "entity.name.type.contract, entity.name.type.interface, entity.name.type.library, entity.name.type.struct, entity.name.type.enum, entity.name.type.event, entity.name.type.error",
+      "scope": "source.solidity entity.name.type.contract, source.solidity entity.name.type.interface, source.solidity entity.name.type.library, source.solidity entity.name.type.struct, source.solidity entity.name.type.enum, source.solidity entity.name.type.event, source.solidity entity.name.type.error",
       "settings": {
         "foreground": "#076678"
       }
     },
     {
-      "scope": "storage.type.modifier.extendedscope",
+      "scope": "source.solidity storage.type.modifier.extendedscope",
       "settings": {
         "foreground": "#8F3F71"
       }
@@ -2074,7 +2074,7 @@
       }
     },
     {
-      "scope": "storage.type.modifier.access, storage.type.modifier.payable, storage.type.modifier.readonly",
+      "scope": "source.solidity storage.type.modifier.access, source.solidity storage.type.modifier.payable, source.solidity storage.type.modifier.readonly",
       "settings": {
         "foreground": "#8B5C42"
       }

--- a/themes/light-rock-color-theme.json
+++ b/themes/light-rock-color-theme.json
@@ -2068,7 +2068,7 @@
       }
     },
     {
-      "scope": "storage.type.function, entity.name.function",
+      "scope": "source.solidity storage.type.function, source.solidity entity.name.function",
       "settings": {
         "foreground": "#5C7A92"
       }
@@ -2080,13 +2080,13 @@
       }
     },
     {
-      "scope": "support.type.primitive",
+      "scope": "source.solidity support.type.primitive",
       "settings": {
         "foreground": "#8B5A2D"
       }
     },
     {
-      "scope": "keyword.control.import, keyword.control.pragma, keyword.control.using, keyword.control.flow",
+      "scope": "source.solidity keyword.control.import, source.solidity keyword.control.pragma, source.solidity keyword.control.using, source.solidity keyword.control.flow",
       "settings": {
         "foreground": "#427B58"
       }

--- a/themes/light-rock-color-theme.json
+++ b/themes/light-rock-color-theme.json
@@ -2050,6 +2050,48 @@
       }
     },
     {
+      "scope": "storage.type.contract, storage.type.interface, storage.type.library, storage.type.struct, storage.type.enum",
+      "settings": {
+        "foreground": "#9D0006"
+      }
+    },
+    {
+      "scope": "entity.name.type.contract, entity.name.type.interface, entity.name.type.library, entity.name.type.struct, entity.name.type.enum, entity.name.type.event, entity.name.type.error",
+      "settings": {
+        "foreground": "#076678"
+      }
+    },
+    {
+      "scope": "storage.type.modifier.extendedscope",
+      "settings": {
+        "foreground": "#8F3F71"
+      }
+    },
+    {
+      "scope": "storage.type.function, entity.name.function",
+      "settings": {
+        "foreground": "#5C7A92"
+      }
+    },
+    {
+      "scope": "storage.type.modifier.access, storage.type.modifier.payable, storage.type.modifier.readonly",
+      "settings": {
+        "foreground": "#8B5C42"
+      }
+    },
+    {
+      "scope": "support.type.primitive",
+      "settings": {
+        "foreground": "#8B5A2D"
+      }
+    },
+    {
+      "scope": "keyword.control.import, keyword.control.pragma, keyword.control.using, keyword.control.flow",
+      "settings": {
+        "foreground": "#427B58"
+      }
+    },
+    {
       "scope": "token.info-token",
       "settings": {
         "foreground": "#076678"

--- a/themes/night-rock-color-theme.json
+++ b/themes/night-rock-color-theme.json
@@ -2504,19 +2504,19 @@
       }
     },
     {
-      "scope": "storage.type.contract, storage.type.interface, storage.type.library, storage.type.struct, storage.type.enum",
+      "scope": "source.solidity storage.type.contract, source.solidity storage.type.interface, source.solidity storage.type.library, source.solidity storage.type.struct, source.solidity storage.type.enum",
       "settings": {
         "foreground": "#EA6962"
       }
     },
     {
-      "scope": "entity.name.type.contract, entity.name.type.interface, entity.name.type.library, entity.name.type.struct, entity.name.type.enum, entity.name.type.event, entity.name.type.error",
+      "scope": "source.solidity entity.name.type.contract, source.solidity entity.name.type.interface, source.solidity entity.name.type.library, source.solidity entity.name.type.struct, source.solidity entity.name.type.enum, source.solidity entity.name.type.event, source.solidity entity.name.type.error",
       "settings": {
         "foreground": "#7DAEA3"
       }
     },
     {
-      "scope": "storage.type.modifier.extendedscope",
+      "scope": "source.solidity storage.type.modifier.extendedscope",
       "settings": {
         "foreground": "#D3869B"
       }
@@ -2528,7 +2528,7 @@
       }
     },
     {
-      "scope": "storage.type.modifier.access, storage.type.modifier.payable, storage.type.modifier.readonly",
+      "scope": "source.solidity storage.type.modifier.access, source.solidity storage.type.modifier.payable, source.solidity storage.type.modifier.readonly",
       "settings": {
         "foreground": "#E78A4E"
       }

--- a/themes/night-rock-color-theme.json
+++ b/themes/night-rock-color-theme.json
@@ -2504,6 +2504,48 @@
       }
     },
     {
+      "scope": "storage.type.contract, storage.type.interface, storage.type.library, storage.type.struct, storage.type.enum",
+      "settings": {
+        "foreground": "#EA6962"
+      }
+    },
+    {
+      "scope": "entity.name.type.contract, entity.name.type.interface, entity.name.type.library, entity.name.type.struct, entity.name.type.enum, entity.name.type.event, entity.name.type.error",
+      "settings": {
+        "foreground": "#7DAEA3"
+      }
+    },
+    {
+      "scope": "storage.type.modifier.extendedscope",
+      "settings": {
+        "foreground": "#D3869B"
+      }
+    },
+    {
+      "scope": "storage.type.function, entity.name.function",
+      "settings": {
+        "foreground": "#A9B665"
+      }
+    },
+    {
+      "scope": "storage.type.modifier.access, storage.type.modifier.payable, storage.type.modifier.readonly",
+      "settings": {
+        "foreground": "#E78A4E"
+      }
+    },
+    {
+      "scope": "support.type.primitive",
+      "settings": {
+        "foreground": "#D8A657"
+      }
+    },
+    {
+      "scope": "keyword.control.import, keyword.control.pragma, keyword.control.using, keyword.control.flow",
+      "settings": {
+        "foreground": "#89B482"
+      }
+    },
+    {
       "scope": "token.info-token",
       "settings": {
         "foreground": "#6796E6"

--- a/themes/night-rock-color-theme.json
+++ b/themes/night-rock-color-theme.json
@@ -2522,7 +2522,7 @@
       }
     },
     {
-      "scope": "storage.type.function, entity.name.function",
+      "scope": "source.solidity storage.type.function, source.solidity entity.name.function",
       "settings": {
         "foreground": "#A9B665"
       }
@@ -2534,13 +2534,13 @@
       }
     },
     {
-      "scope": "support.type.primitive",
+      "scope": "source.solidity support.type.primitive",
       "settings": {
         "foreground": "#D8A657"
       }
     },
     {
-      "scope": "keyword.control.import, keyword.control.pragma, keyword.control.using, keyword.control.flow",
+      "scope": "source.solidity keyword.control.import, source.solidity keyword.control.pragma, source.solidity keyword.control.using, source.solidity keyword.control.flow",
       "settings": {
         "foreground": "#89B482"
       }


### PR DESCRIPTION
## Summary

This PR adds dedicated token color rules for Solidity language constructs to improve visual distinction between different code elements.

### Changes

Adds specific TextMate scope rules for Solidity syntax highlighting across all three theme variants (Dark Rock, Light Rock, Night Rock):

| Token | Description |
|-------|-------------|
| `storage.type.contract`, etc. | Contract/interface/struct keywords → Red |
| `entity.name.type.contract`, etc. | Type/contract names → Cyan/Blue |
| `storage.type.modifier.extendedscope` | Modifiers (abstract, virtual, override) → Pink/Purple |
| `storage.type.function`, `entity.name.function` | Function definitions → Green |
| `storage.type.modifier.access`, etc. | Access modifiers (public, private) → Orange |
| `support.type.primitive` | Primitive types (uint256, address) → Yellow |
| `keyword.control.import`, etc. | Control keywords (import, pragma) → Aqua/Teal |

### Before
All keywords like `abstract`, `contract`, and `TimedRoles` appeared in the same color.

### After
- `abstract` → Pink (modifier)
- `contract` → Red (keyword)
- `TimedRoles` → Cyan (type name)

Fixes #2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Solidity TextMate scopes (contracts/types/modifiers/functions/primitives/control keywords) to Dark Rock, Light Rock, and Night Rock themes.
> 
> - **Language support**
>   - **Solidity**: add token color rules in `themes/dark-rock-color-theme.json`, `themes/light-rock-color-theme.json`, and `themes/night-rock-color-theme.json` for:
>     - `storage.type.(contract|interface|library|struct|enum)`
>     - `entity.name.type.(contract|interface|library|struct|enum|event|error)`
>     - `storage.type.modifier.(extendedscope|access|payable|readonly)`
>     - `storage.type.function`, `entity.name.function`
>     - `support.type.primitive`
>     - `keyword.control.(import|pragma|using|flow)`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ec387957e83a06e2fb4162a185ac899a159350c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->